### PR TITLE
Search the PATH for Helm

### DIFF
--- a/syncctl.py
+++ b/syncctl.py
@@ -82,6 +82,7 @@ def download_file(url: str, dest: str, hash: str = None) -> None:
 def download_chart(name: str, version: str, repository: str) -> dict:
     with tempfile.TemporaryDirectory() as tmpdirname:
         env = {
+            "PATH": os.environ.copy().get('PATH'),
             "HELM_CACHE_HOME": f'{tmpdirname}',
             "HELM_CONFIG_HOME": f'{tmpdirname}'
         }


### PR DESCRIPTION
Helm is often installed into /usr/local/bin, which apparently isn't
searched, when the PATH environment variable isn't set, so set PATH to
the PATH from the current environment, so all the PATHs defined by the
user/system are searched.

Fixes: https://github.com/distributed-technologies/syncctl/commit/035ffb0e97459651ae731ec7cba0735abf8116f4 ("Support Helm version constraints")